### PR TITLE
feat: controlled state test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@birdwingo/react-native-swipe-modal",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "A versatile and smooth swipeable modal component for React Native applications.",
   "main": "src/index.tsx",
   "source": "src/index.tsx",

--- a/src/components/AnimatedModal/index.tsx
+++ b/src/components/AnimatedModal/index.tsx
@@ -46,7 +46,8 @@ const AnimatedModal = forwardRef<AnimatedModalPublicMethods, AnimatedModalProps>
 
   // default visibility should never change, hence useMemo with empty dependency array
   // eslint-disable-next-line max-len
-  const defaultVisibility: boolean = useMemo( () => ( props.controlled ? props.open : ( props.visible ?? false ) ), [] );
+  const defaultVisibility: boolean = useMemo( () => ( 'open' in props && typeof props.open === 'boolean' ? props.open : ( props.visible ?? false ) ), [] );
+  const controlledVisibility: boolean | undefined = useMemo( () => props.open, [ props.open ] );
 
   const [ isVisible, setIsVisible ] = useState( defaultVisibility );
   const animation = useSharedValue( defaultVisibility ? 1 : 0 );
@@ -56,20 +57,24 @@ const AnimatedModal = forwardRef<AnimatedModalPublicMethods, AnimatedModalProps>
   useEffect( () => {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    props.controlled && setIsVisible( props.open );
+    typeof controlledVisibility === 'boolean' && setIsVisible( controlledVisibility );
 
-  }, [ props.controlled, props.open ] );
+  }, [ controlledVisibility ] );
 
   // handle bottom-up controlled state
   useEffect( () => {
 
-    if ( props.controlled && isVisible !== props.open ) {
+    if ( typeof controlledVisibility === 'boolean' && isVisible !== controlledVisibility ) {
 
-      props.setOpen( isVisible );
+      if ( typeof props.setOpen === 'function' ) {
+
+        props.setOpen( isVisible );
+
+      }
 
     }
 
-  }, [ isVisible ] );
+  }, [ isVisible, controlledVisibility ] );
 
   // eslint-disable-next-line max-len
   const animatedPressableStyle = useAnimatedStyle( () => ( { opacity: interpolate( animation.value, [ 0, 1 ], [ 0, closeSpaceVisibility ] ) } ), [] );

--- a/src/core/dto/animatedModalDTO.ts
+++ b/src/core/dto/animatedModalDTO.ts
@@ -1,8 +1,11 @@
 import { ReactNode } from 'react';
 
-export interface AnimatedModalProps {
-  children: ReactNode | ReactNode[];
+export type AnimatedModalBaseProps = {
+  controlled?: boolean;
+  open?: boolean;
+  setOpen?: ( value: boolean ) => void;
   visible?: boolean;
+  children: ReactNode | ReactNode[];
   onShow?: () => void;
   onHide?: () => void;
   closeOnEmptySpace?: boolean;
@@ -11,7 +14,23 @@ export interface AnimatedModalProps {
   closeSpaceVisibility?: number;
   hideKeyboardOnShow?: boolean;
   useKeyboardAvoidingView?: boolean;
-}
+};
+
+export type ControlledAnimatedModalProps = AnimatedModalBaseProps & {
+  visible?: never;
+  controlled: true;
+  open: boolean;
+  setOpen: ( value: boolean ) => void;
+};
+
+export type ForwardRefAnimatedModalProps = AnimatedModalBaseProps & {
+  visible?: boolean;
+  controlled?: never;
+  open?: never;
+  setOpen?: never;
+};
+
+export type AnimatedModalProps = ControlledAnimatedModalProps | ForwardRefAnimatedModalProps;
 
 export type AnimatedModalPublicMethods = {
   show: () => void;

--- a/src/core/dto/animatedModalDTO.ts
+++ b/src/core/dto/animatedModalDTO.ts
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react';
 
 export type AnimatedModalBaseProps = {
-  controlled?: boolean;
   open?: boolean;
   setOpen?: ( value: boolean ) => void;
   visible?: boolean;
@@ -18,14 +17,12 @@ export type AnimatedModalBaseProps = {
 
 export type ControlledAnimatedModalProps = AnimatedModalBaseProps & {
   visible?: never;
-  controlled: true;
   open: boolean;
   setOpen: ( value: boolean ) => void;
 };
 
 export type ForwardRefAnimatedModalProps = AnimatedModalBaseProps & {
   visible?: boolean;
-  controlled?: never;
   open?: never;
   setOpen?: never;
 };

--- a/src/core/dto/swipeModalDTO.ts
+++ b/src/core/dto/swipeModalDTO.ts
@@ -1,10 +1,10 @@
-import { ReactNode } from 'react';
+import { ReactNode, RefObject } from 'react';
 import { ViewProps, ViewStyle } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { SharedValue } from 'react-native-reanimated';
 import { AnimatedModalProps } from './animatedModalDTO';
 
-export interface SwipeModalProps extends AnimatedModalProps {
+export type SwipeModalProps = AnimatedModalProps & {
   children: ReactNode | ReactNode[];
   bg?: string;
   showBar?: boolean;
@@ -25,7 +25,7 @@ export interface SwipeModalProps extends AnimatedModalProps {
   topOffset?: number;
   containerProps?: ViewProps;
   wrapInGestureHandlerRootView?: boolean;
-}
+};
 
 export type SwipeModalPublicMethods = {
   show: () => void;
@@ -34,7 +34,7 @@ export type SwipeModalPublicMethods = {
 
 export interface ModalScrollContainerProps {
   children: ReactNode;
-  scrollRef: React.RefObject<ScrollView>;
+  scrollRef: RefObject<ScrollView>;
   style?: SwipeModalProps['scrollContainerStyle'];
   props?: SwipeModalProps['scrollContainerProps'];
   scrollY: SharedValue<number>;

--- a/src/core/dto/swipeModalDTO.ts
+++ b/src/core/dto/swipeModalDTO.ts
@@ -5,7 +5,6 @@ import { SharedValue } from 'react-native-reanimated';
 import { AnimatedModalProps } from './animatedModalDTO';
 
 export type SwipeModalProps = AnimatedModalProps & {
-  children: ReactNode | ReactNode[];
   bg?: string;
   showBar?: boolean;
   barColor?: string;


### PR DESCRIPTION
For our app, we wanted to move to a more modern approach with React, which is to use Controlled Components/States instead of needing to instantiate a bunch of refs, pass those refs, wait for those refs`.current` to not be `null`, and then call the methods exposed to those refs. 

The thought process, here, is that it is simply much easier to pass an `open` state (`boolean`) and a `setOpen` callback (`(open: boolean) => void`) to the component. From the top level, all I need to do is call `setOpen(true)`.

This PR is probably not ready to ship at this exact moment, but I wanted to open it up for feedback and peer review. I turned on `Allow edits by maintainers` and welcome edits/fixes/etc.