### PR TITLE
fix: allow modal to respond to downward swipes after fast upward scroll

### DIFF
--- a/src/components/SwipeModal/scroll.tsx
+++ b/src/components/SwipeModal/scroll.tsx
@@ -31,7 +31,7 @@ const ModalScrollView: FC<ModalScrollContainerProps> = ( {
       }}
       onScroll={( e ) => {
 
-        if ( e.nativeEvent.contentOffset.y > 0 ) {
+        if ( e.nativeEvent.contentOffset.y >= 0 ) {
 
           scrollY.value = e.nativeEvent.contentOffset.y;
 


### PR DESCRIPTION
When swiping up quickly in a modal’s scroll view, if the touch ends before the scroll view reaches the top, the modal does not respond to the next downward swipe. This happens because the scroll continues after onScrollEndDrag and the scroll offset check in onScroll was strictly > 0, preventing the modal from resetting properly when the scroll is at the top.